### PR TITLE
Revised order hashing

### DIFF
--- a/contracts/Exchange.sol
+++ b/contracts/Exchange.sol
@@ -189,7 +189,6 @@ contract Exchange is Owned {
             emit LogError(uint8(Errors.TRADE_ALREADY_COMPLETED_OR_CANCELLED), tradeHash);
             return false;
         }
-        traded[tradeHash] = true;
 
         if (filled[orderHash].add(trade.amount) > order.amountBuy) {
             emit LogError(uint8(Errors.TRADE_AMOUNT_TOO_BIG), orderHash);
@@ -206,6 +205,7 @@ contract Exchange is Owned {
             return false;
         }
 
+        traded[tradeHash] = true;
         uint filledAmountSell = getPartialAmount(trade.amount, order.amountBuy, order.amountSell);
 
         filled[orderHash] = filled[orderHash].add(trade.amount);

--- a/test/utils/exchange.js
+++ b/test/utils/exchange.js
@@ -1,63 +1,67 @@
-import { soliditySha3 as keccak256 } from 'web3-utils'
+import {soliditySha3 as keccak256} from 'web3-utils'
 
 export const getOrderHash = (exchange, order) => {
-  return keccak256(
-    exchange.address,
-    order.tokenBuy,
-    order.amountBuy,
-    order.tokenSell,
-    order.amountSell,
-    order.expires,
-    order.nonce,
-    order.maker
-  )
+    return keccak256(
+        exchange.address,
+        order.maker,
+        order.tokenSell,
+        order.tokenBuy,
+        order.amountSell,
+        order.amountBuy,
+        order.feeMake,
+        order.feeTake,
+        order.expires,
+        order.nonce
+    )
 };
 
 export const getTradeHash = (orderHash, trade) => {
-  return keccak256(
-    orderHash,
-    trade.amount,
-    trade.taker,
-    trade.tradeNonce
-  )
+    return keccak256(
+        orderHash,
+        trade.taker,
+        trade.amount,
+        trade.tradeNonce
+    )
 };
 
 export const getMatchOrderValues = (order, trade) => {
-  return [
-    order.amountBuy,
-    order.amountSell,
-    order.expires,
-    order.nonce,
-    order.feeMake,
-    order.feeTake,
-    trade.amount,
-    trade.tradeNonce
-  ]
+    return [
+        order.amountBuy,
+        order.amountSell,
+        order.expires,
+        order.nonce,
+        order.feeMake,
+        order.feeTake,
+        trade.amount,
+        trade.tradeNonce
+    ]
 };
 
 export const getMatchOrderAddresses = (order, trade) => {
-  return [
-    order.tokenBuy,
-    order.tokenSell,
-    order.maker,
-    trade.taker
-  ]
+    return [
+        order.tokenBuy,
+        order.tokenSell,
+        order.maker,
+        trade.taker
+    ]
 };
 
 
 export const getCancelOrderValues = (order) => {
-  return [
-    order.amountBuy,
-    order.amountSell,
-    order.expires,
-    order.nonce
-  ]
+    return [
+        order.amountBuy,
+        order.amountSell,
+        order.expires,
+        order.nonce,
+        order.feeMake,
+        order.feeTake
+    ]
 };
 
 export const getCancelOrderAddresses = (order) => {
-  return [
-    order.tokenBuy,
-    order.tokenSell,
-    order.maker
-  ]
+    return [
+        order.tokenBuy,
+        order.tokenSell,
+        order.maker
+    ]
 };


### PR DESCRIPTION
### Refactor order hashing logic & Remove the 'TrimmedOrder' struct

Include the 'makerFee' & 'takerFee' parameter in order hash generation.

As a result, the 'cancelOrder' function will now need an 'Order' struct instead of 'TrimmedOrder' struct as 'TrimmedOrder' struct does not include 'makerFee' & 'takerFee'.

'TrimmedOrder' struct has no more usages & hence removed.

Added two reusable internal function's named 'getOrderHash' & 'getTradeHash' to generate order & trade hash respectively and invoked them where order or trade hash were required.

The hash generating utility functions used in exchange unit tests have also been refactored according to new hashing logic.