### PR TITLE
Prevent owner from configuring zero address as operator or fee account

### DIFF
--- a/contracts/Exchange.sol
+++ b/contracts/Exchange.sol
@@ -102,16 +102,18 @@ contract Exchange is Owned {
     /// @param _feeAccount An address to set as fees account.
     /// @return Success on setting fees account.
     function setFeeAccount(address _feeAccount) public onlyOwner returns (bool) {
+        require(_feeAccount != address(0));
         feeAccount = _feeAccount;
         return true;
     }
 
     /// @dev Sets or unset's an operator.
-    /// @param operator The address of operator to set.
-    /// @param isOperator Bool value indicating whether the address is operator or not.
+    /// @param _operator The address of operator to set.
+    /// @param _isOperator Bool value indicating whether the address is operator or not.
     /// @return Success on setting an operator.
-    function setOperator(address operator, bool isOperator) public onlyOwner returns (bool) {
-        operators[operator] = isOperator;
+    function setOperator(address _operator, bool _isOperator) public onlyOwner returns (bool) {
+        require(_operator != address(0));
+        operators[_operator] = _isOperator;
         return true;
     }
 

--- a/contracts/Exchange.sol
+++ b/contracts/Exchange.sol
@@ -101,7 +101,7 @@ contract Exchange is Owned {
     /// @dev Sets the address of fees account.
     /// @param _feeAccount An address to set as fees account.
     /// @return Success on setting fees account.
-    function setFeeAccount(address _feeAccount) public onlyOperator returns (bool) {
+    function setFeeAccount(address _feeAccount) public onlyOwner returns (bool) {
         feeAccount = _feeAccount;
         return true;
     }

--- a/test/utils/exchange.js
+++ b/test/utils/exchange.js
@@ -1,63 +1,67 @@
-import { soliditySha3 as keccak256 } from 'web3-utils'
+import {soliditySha3 as keccak256} from 'web3-utils'
 
 export const getOrderHash = (exchange, order) => {
-  return keccak256(
-    exchange.address,
-    order.tokenBuy,
-    order.amountBuy,
-    order.tokenSell,
-    order.amountSell,
-    order.expires,
-    order.nonce,
-    order.maker
-  )
+    return keccak256(
+        exchange.address,
+        order.maker,
+        order.tokenSell,
+        order.tokenBuy,
+        order.amountSell,
+        order.amountBuy,
+        order.feeMake,
+        order.feeTake,
+        order.expires,
+        order.nonce
+    )
 };
 
 export const getTradeHash = (orderHash, trade) => {
-  return keccak256(
-    orderHash,
-    trade.amount,
-    trade.taker,
-    trade.tradeNonce
-  )
+    return keccak256(
+        orderHash,
+        trade.taker,
+        trade.amount,
+        trade.tradeNonce
+    )
 };
 
 export const getMatchOrderValues = (order, trade) => {
-  return [
-    order.amountBuy,
-    order.amountSell,
-    order.expires,
-    order.nonce,
-    order.feeMake,
-    order.feeTake,
-    trade.amount,
-    trade.tradeNonce
-  ]
+    return [
+        order.amountBuy,
+        order.amountSell,
+        order.expires,
+        order.nonce,
+        order.feeMake,
+        order.feeTake,
+        trade.amount,
+        trade.tradeNonce
+    ]
 };
 
 export const getMatchOrderAddresses = (order, trade) => {
-  return [
-    order.tokenBuy,
-    order.tokenSell,
-    order.maker,
-    trade.taker
-  ]
+    return [
+        order.tokenBuy,
+        order.tokenSell,
+        order.maker,
+        trade.taker
+    ]
 };
 
 
 export const getCancelOrderValues = (order) => {
-  return [
-    order.amountBuy,
-    order.amountSell,
-    order.expires,
-    order.nonce
-  ]
+    return [
+        order.amountBuy,
+        order.amountSell,
+        order.expires,
+        order.nonce,
+        order.feeMake,
+        order.feeTake
+    ]
 };
 
 export const getCancelOrderAddresses = (order) => {
-  return [
-    order.tokenBuy,
-    order.tokenSell,
-    order.maker
-  ]
+    return [
+        order.tokenBuy,
+        order.tokenSell,
+        order.maker
+    ]
 };


### PR DESCRIPTION
'setFeeAccount' & 'setOperator' functions have been updated to have zero
address checks so that the owner can not wrongly configure operator or
fee account to zero address.