### PR TITLE
Refactor 'Fee account management' unit tests

### DIFF
--- a/test/exchange.js
+++ b/test/exchange.js
@@ -132,18 +132,16 @@ contract('Exchange', (accounts) => {
             newFeeAccount.should.be.equal(expectedNewFeeAccount)
         });
 
-        it('should set fee account if requested by operator', async () => {
-            let expectedNewFeeAccount = accounts[3];
-            await exchange.setFeeAccount(expectedNewFeeAccount, {from: operator});
-
-            let newFeeAccount = await exchange.feeAccount.call();
-            newFeeAccount.should.be.equal(expectedNewFeeAccount)
-        });
-
         it('should not set fee account if not requested by owner or operator', async () => {
             let expectedNewFeeAccount = accounts[3];
-            await expectRevert(exchange.setFeeAccount(expectedNewFeeAccount, {from: anyUser}))
-        })
+            await expectRevert(exchange.setFeeAccount(expectedNewFeeAccount, {from: operator}));
+            await expectRevert(exchange.setFeeAccount(expectedNewFeeAccount, {from: anyUser}));
+        });
+
+        it('should not set zero address as fee account', async () => {
+            let newFeeAccount = "0x0000000000000000000000000000000000000000";
+            await expectRevert(exchange.setFeeAccount(newFeeAccount, {from: owner}));
+        });
     });
 
     describe('Cancelling order', async () => {


### PR DESCRIPTION
- 'should set fee account if requested by operator' unit test has been removed as the operator can no more set fees account.

- 'should not set fee account if not requested by owner or operator' unit test has been updated to check that transaction reverts if operator tries to set fee account.

- 'should not set zero address as fee account' unit test has been added to test that the owner can not wrongly configure fee account as zero address.